### PR TITLE
Bugfixes, remove dependency pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,60 +42,69 @@ c.GitPlus.github_token = '<your-github-access-token>'
 
 After installation, start JupyterLab normally & you should see "Git-Plus" as a new menu item at the top.
 
+#### 2.1 Configuring a custom reviewnb URL
+
+Suppose your company uses a custom reviewnb URL, e.g. `https://reviewnb.yourdomain.com`. You can configure
+gitplus to link users to PRs/commits at this URL instead of the default one as follows:
+
+```python
+c.GitPlus.self_hosted_reviewnb_endpoint = "https://reviewnb.yourdomain.com/"
+```
+
 ## FAQ
-<details> 
+<details>
   <summary>Where is pull request (PR) opened in case of forked repositories?</summary>
   <p>
-    
-  If your repository is forked from another repository (parent) then PR will be created on parent repository. 
+
+  If your repository is forked from another repository (parent) then PR will be created on parent repository.
 </p></details>
 
-<details> 
+<details>
   <summary> Which is the <tt>base</tt> branch used in a pull request? </summary>
   <p>
-  
-  `base` branch in a PR is a branch against which your changes are compared and ultimately merged. We use repository's default    branch (usually called `master`) as `base` branch of PR. We use parent repository's default branch as `base` in case of forked repo. 
+
+  `base` branch in a PR is a branch against which your changes are compared and ultimately merged. We use repository's default    branch (usually called `master`) as `base` branch of PR. We use parent repository's default branch as `base` in case of forked repo.
 </p></details>
 
-<details> 
+<details>
   <summary>Which is the <tt>head</tt> branch used in a pull request?</summary>
   <p>
-    
-  `head` branch in a PR is a branch which contains the latest changes you've made. We create a new branch (e.g. `gitplus-xyz123`) as `head` branch. It only contains changes from the files you wish to include in the PR.  
+
+  `head` branch in a PR is a branch which contains the latest changes you've made. We create a new branch (e.g. `gitplus-xyz123`) as `head` branch. It only contains changes from the files you wish to include in the PR.
 </p></details>
 
-<details> 
+<details>
   <summary>How can I edit a pull request opened with GitPlus?</summary>
   <p>
 
-You can head over to GitHub and edit the PR metadata to your liking. For pushing additional file changes to the same PR, 
-1. Copy the branch name from GitHub UI (e.g. `gitplus-xyz123`) 
+You can head over to GitHub and edit the PR metadata to your liking. For pushing additional file changes to the same PR,
+1. Copy the branch name from GitHub UI (e.g. `gitplus-xyz123`)
 2. Checkout that branch locally
 3. Make the file changes you want
 4. Use push commit functionality from GitPlus to push new changes
 </p></details>
 
-<details> 
+<details>
   <summary>Is GitPlus tied to ReviewNB in any way?</summary>
   <p>
-    
+
   No. GitPlus is it's own open source project. The only connection with ReviewNB is that at the end of PR/Commit creation, GitPlus shows ReviewNB URL along with GitHub URL. You can safely ignore these URLs if you don't want to use ReviewNB.
-  
+
   It's is useful to see [visual notebook diffs](https://uploads-ssl.webflow.com/5ba4ebe021cb91ae35dbf88c/5ba93ded243329a486dab26e_sl-code%2Bimage.png) on ReviewNB instead of hard to read [JSON diffs](https://uploads-ssl.webflow.com/5ba4ebe021cb91ae35dbf88c/5c24ba833c78e57d6b8c9d09_Screenshot%202018-12-27%20at%204.43.09%20PM.png) on GitHub. [ReviewNB](https://www.reviewnb.com/) also facilitates discussion on notebooks cells.
 </p></details>
 
-<details> 
+<details>
   <summary>What if I don't have a ReviewNB account?</summary>
   <p>
-    
+
   No problem, everything in GitPlus will still work fine. Only the ReviewNB URLs won't work for you.
 <p></details>
 
 
-<details> 
+<details>
   <summary>Can we use GitPlus with Gitlab/BitBucket or any other platforms?</summary>
   <p>
-    
+
   No, currently we only support repositories on GitHub.
 <p></details>
 
@@ -139,4 +148,3 @@ pip install .
 
 ## Contributing
 If you see any problem, open an issue or send a pull request. You can write to support@reviewnb.com for any questions.
-

--- a/jupyterlab_gitplus/__init__.py
+++ b/jupyterlab_gitplus/__init__.py
@@ -28,7 +28,7 @@ def _jupyter_server_extension_paths():
     }]
 
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 
 def _load_jupyter_server_extension(nb_server_app):

--- a/jupyterlab_gitplus/github_v3.py
+++ b/jupyterlab_gitplus/github_v3.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 GITHUB_REST_ENDPOINT = 'https://api.github.com/'
 
 
-def create_pull_request(owner_login, repo_name, title, head, base, access_token):
+def create_pull_request(owner_login, repo_name, title, head, base, access_token, reviewnb_endpoint):
     content = {}
     url = GITHUB_REST_ENDPOINT + 'repos/' + owner_login + '/' + repo_name + '/pulls'
     headers = {
@@ -28,7 +28,7 @@ def create_pull_request(owner_login, repo_name, title, head, base, access_token)
         response.raise_for_status()
         result = {
             'github_url': content['html_url'],
-            'reviewnb_url': content['html_url'].replace('github.com', 'app.reviewnb.com')
+            "reviewnb_url": content['html_url'].replace('https://github.com/', reviewnb_endpoint)
         }
         return result
     except Exception as ex:

--- a/jupyterlab_gitplus/utils.py
+++ b/jupyterlab_gitplus/utils.py
@@ -2,8 +2,11 @@
 import re
 import os
 import stat
+import logging
+_logger = logging.getLogger(__name__)
 
-GITHUB_REMOTE_URL_REGEX = re.compile(r"github\.com\/(.*?)\/(.*?)\.git")
+GITHUB_REMOTE_URL_REGEX = re.compile(r"github\.com[:\/](.*?)\/(.*?)\.git")
+
 
 def get_owner_login_and_repo_name(repo):
     owner_login, repo_name = '', ''
@@ -17,6 +20,9 @@ def get_owner_login_and_repo_name(repo):
     if match:
         owner_login = match.group(1)
         repo_name = match.group(2)
+        _logger.info(f"For git repo {remote_url}, found {owner_login}/{repo_name}")
+    else:
+        _logger.error(f"Unable to find owner/repo name for repo {remote_url}")
 
     return owner_login, repo_name
 

--- a/jupyterlab_gitplus/utils.py
+++ b/jupyterlab_gitplus/utils.py
@@ -3,7 +3,7 @@ import re
 import os
 import stat
 import logging
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 GITHUB_REMOTE_URL_REGEX = re.compile(r"github\.com[:\/](.*?)\/(.*?)\.git")
 
@@ -20,9 +20,9 @@ def get_owner_login_and_repo_name(repo):
     if match:
         owner_login = match.group(1)
         repo_name = match.group(2)
-        _logger.info(f"For git repo {remote_url}, found {owner_login}/{repo_name}")
+        logger.info(f"For git repo {remote_url}, found {owner_login}/{repo_name}")
     else:
-        _logger.error(f"Unable to find owner/repo name for repo {remote_url}")
+        logger.error(f"Unable to find owner/repo name for repo {remote_url}")
 
     return owner_login, repo_name
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup_args = dict(
         'gitpython',
         'requests',
         'urllib3',
-        'jupyter_server>=1.6,<2'
+        'jupyter_server>=1.6,<3'
     ]
 )
 


### PR DESCRIPTION
Bugfixes:

- SSH github URLs such as `git@github.com:ReviewNB/jupyterlab-gitplus` did not work. Now they do.
- Some users of reviewnb have custom URLs, often accessible only behind a VPN. For example mine is `https://reviewnb.team.affirm.com`. Now you can configure such URLs.
- This plugin actually works just fine with `jupyter-server>2`, I tested it with `jupyter-server==2.14.0`. I've bumped the pin to jupyter-server<3.

Happy to modify or split this into pieces, I did my best to match existing code style but I do see this is an unsolicited PR.